### PR TITLE
ci: add github actions workflow to run test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHONUNBUFFERED: 1
+  FORCE_COLOR: 1
+  CLICOLOR_FORCE: 1
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install --editable .
+      - run: python -m pip install pytest
+      - run: pytest pydracor/test_dracor.py -v -ra --showlocals


### PR DESCRIPTION
Hi, this is my first PR to the project.

This PR adds a minimal GitHub actions workflow to run the test suite with pytest.

But this takes rather long.

I would like to contribute a few more changes, if you like. Please say no, if not.