### PR TITLE
build: drop support for python <= 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
   { name = "Eduard Grigoriev", email = "happypuffin7@gmail.com" },
   { name = "Henny Sluyter-Gäthje", email = "sluytergaeth@uni-potsdam.de" },
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
@@ -26,10 +26,11 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Education",
   "Topic :: Software Development",
   "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
Python 3.6 and 3.7 reached their end of life in 2021 and 2023.

I propose dropping their support and adding Python 3.10-3.12.

Refs:
- https://devguide.python.org/versions/