### PR TITLE
build: add version variable to init.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,18 @@ jobs:
       - run: python -m pip install --editable .
       - run: python -m pip install pytest
       - run: pytest pydracor/test_dracor.py -v -ra --showlocals
+
+  importable:
+    name: "Importable on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -Im pip install .
+      - run: python -Ic 'import pydracor; print(pydracor.__version__)'

--- a/pydracor/__init__.py
+++ b/pydracor/__init__.py
@@ -1,1 +1,6 @@
+from importlib.metadata import version  
+
 from pydracor.dracor import DraCor, Corpus, Play, Character, Wikidata
+
+
+__version__ = version("pydracor")  


### PR DESCRIPTION
This PR proposes the following changes:

- add a `__version__` variable to `__init__.py`, that reads from the version defined in pyproject.toml
- add a minimal CI check, that tests if the project runs on the most common OSes

Refs:
- https://packaging.python.org/en/latest/guides/single-sourcing-package-version/

Possible follow-up: Use the version variable in a user agent for the API client.

Instead of using the generic user-agent `python-requests/2.31.0` (is used now), it would be more polite to use `pydracor/2.0.0`. This way the API logs can also give insights into the usage of the different client versions.